### PR TITLE
feat: add JWT service-to-service authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,17 @@
 # Notification System
 
-A microservice for sending notifications via email, SMS, and push notifications. Built with FastAPI, SQLAlchemy, PostgreSQL, Celery, and RabbitMQ.
+A microservice for sending notifications via email, SMS, and push notifications. Built with FastAPI, SQLAlchemy, PostgreSQL, RabbitMQ (direct consumer pattern), and structured JSON logging.
 
 ## Features
 
 - **Multi-Channel Notifications** — Send via email (SendGrid), SMS (Twilio), push (Firebase)
 - **Scheduled Notifications** — Schedule delivery at a future time
 - **Priority Queuing** — Critical alerts delivered first
-- **Asynchronous Processing** — Celery + RabbitMQ handles delivery without blocking the API
+- **Direct MQ Consumer** — No Celery, worker consumes RabbitMQ directly with pika
+- **Retry with Backoff** — 3 retry attempts (1s, 2s, 4s delays) on send failure
+- **Idempotency** — Worker skips already-processed notifications
 - **Structured Logging** — JSON-formatted logs for production observability
+- **JWT Service Auth** — Service-to-service authentication with scoped tokens
 
 ## Architecture
 
@@ -17,11 +20,13 @@ A microservice for sending notifications via email, SMS, and push notifications.
 │   FastAPI   │────▶│  PostgreSQL  │     │  RabbitMQ  │
 │   (REST)   │     │  (metadata) │     │  (broker)  │
 └─────────────┘     └──────────────┘     └─────────────┘
-       │                                         │
-       │         ┌──────────────┐                 │
-       └────────▶│   Celery     │◀────────────────┘
-                 │   Worker    │
-                 └──────────────┘
+       │                                        │
+       └────────────────┬──────────────────────┘
+                        │
+                   ┌────▼────┐
+                   │ Worker  │ (NotificationConsumer)
+                   │ (pika)  │
+                   └────┬────┘
                         │
               ┌─────────┼─────────┐
               ▼         ▼         ▼
@@ -29,20 +34,23 @@ A microservice for sending notifications via email, SMS, and push notifications.
          (SendGrid) (Twilio)  (FCM)
 ```
 
-## Quick Start
-
-```bash
-# Start all services
-make up
-
-# API available at http://localhost:8000/docs
-```
-
 ## API Endpoints
 
-### Create Notification
+### Authentication
+```bash
+# Get service token
+POST /api/v1/auth/token
+{
+  "service_id": "my-service",
+  "service_secret": "service-secret",
+  "scope": ["notifications:read", "notifications:write"]
+}
+```
+
+### Create Notification (requires `notifications:write` scope)
 ```bash
 POST /api/v1/notifications/
+Authorization: Bearer <token>
 {
   "user_ids": [1, 2],
   "channel": "email",
@@ -52,14 +60,25 @@ POST /api/v1/notifications/
 }
 ```
 
-### Get Notification
+### Get Notification (requires `notifications:read` scope)
 ```bash
 GET /api/v1/notifications/{id}
+Authorization: Bearer <token>
 ```
 
-### List Notifications
+### List Notifications (requires `notifications:read` scope)
 ```bash
 GET /api/v1/notifications/?page=1&page_size=10
+Authorization: Bearer <token>
+```
+
+## Quick Start
+
+```bash
+# Start all services (Docker)
+make up
+
+# API available at http://localhost:8000/docs
 ```
 
 ## Environment Variables
@@ -67,8 +86,9 @@ GET /api/v1/notifications/?page=1&page_size=10
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `DATABASE_URL` | PostgreSQL connection string | Required |
-| `CELERY_BROKER_URL` | RabbitMQ connection | `amqp://guest:guest@rabbitmq:5672//` |
-| `CELERY_RESULT_BACKEND` | Celery result backend | `rpc://guest:guest@rabbitmq:5672//` |
+| `CELERY_BROKER_URL` | RabbitMQ connection | `amqp://guest:guest@rabbitmq:5672/` |
+| `JWT_SECRET_KEY` | Secret key for JWT signing | Must change in prod |
+| `SERVICE_API_SECRET` | Service credential for token mint | `service-secret-change-in-production` |
 | `SENDGRID_API_KEY` | SendGrid API key | Optional |
 | `SENDGRID_FROM_EMAIL` | Sender email | Optional |
 | `TWILIO_ACCOUNT_SID` | Twilio account | Optional |
@@ -109,9 +129,10 @@ app/
 ├── services/               # Business logic
 │   ├── notification_service.py
 │   ├── channel_services.py # Email/SMS/Push factories
-│   └── recipient_resolver.py
-├── utils/                  # Validators, interfaces, utilities
-├── worker/                 # Celery tasks
+│   ├── recipient_resolver.py
+│   └── rabbitmq_publisher.py  # Direct MQ publisher
+├── worker/
+│   └── consumer.py         # Direct RabbitMQ consumer (pika)
 └── tests/                  # Test suite
 ```
 
@@ -120,3 +141,30 @@ app/
 **notifications** — id, sender_user_id, subject, priority, channel, content, status, scheduled_at, sent_at, created_at, updated_at
 
 **notification_recipients** — id, notification_id, user_id, email, phone_number, push_token, status, delivered_at, failed_reason, retry_count
+
+## Notification Flow
+
+```
+API Request → NotificationService.create_notification()
+           → Create DB record (PENDING)
+           → Resolve recipients
+           → Publish to RabbitMQ (RabbitMQPublisher)
+           → Update status (QUEUED)
+           → Return NotificationResponse
+
+Worker → NotificationConsumer._process_message()
+      → Check if already SENT (idempotency)
+      → NotificationService.process_notification()
+      → ChannelServiceFactory.create_service(channel)
+      → Send via provider (SendGrid/Twilio/FCM)
+      → Update status (SENT or FAILED on exhaustion)
+
+## Authentication Flow
+
+```
+1. Service calls POST /api/v1/auth/token with service_id + service_secret
+2. API returns JWT token with scopes (expires in 60 min)
+3. Service includes JWT in Authorization: Bearer <token> header
+4. Protected endpoints validate JWT and check required scopes
+```
+```

--- a/app/api/endpoints/auth.py
+++ b/app/api/endpoints/auth.py
@@ -1,0 +1,46 @@
+from fastapi import APIRouter, HTTPException, status
+from pydantic import BaseModel
+from app.core.auth import create_service_token, ServiceTokenResponse
+from app.core.config import settings
+import logging
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["Auth"])
+
+
+class TokenRequest(BaseModel):
+    """Request body for service token generation."""
+    service_id: str
+    service_secret: str
+    scope: list[str] = ["notifications:read", "notifications:write"]
+
+
+class TokenError(BaseModel):
+    detail: str
+
+
+@router.post("/token", response_model=ServiceTokenResponse, responses={401: {"model": TokenError}})
+async def get_service_token(request: TokenRequest):
+    """
+    Generate a JWT token for service-to-service authentication.
+
+    Services call this endpoint with their service_id and service_secret to obtain
+    a short-lived JWT token. Tokens expire after JWT_EXPIRY_MINUTES (default 60).
+
+    In production, service_secret should be stored securely (e.g., AWS Secrets Manager).
+    For now, it must match the SERVICE_API_SECRET env var.
+    """
+    if request.service_secret != settings.SERVICE_API_SECRET:
+        logger.warning("Invalid service credentials", extra={"service_id": request.service_id})
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid service credentials",
+        )
+
+    token_response = create_service_token(
+        service_id=request.service_id,
+        scope=request.scope,
+    )
+    logger.info("Service token issued", extra={"service_id": request.service_id})
+    return token_response

--- a/app/api/endpoints/notification.py
+++ b/app/api/endpoints/notification.py
@@ -1,8 +1,9 @@
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Security, status
 from sqlalchemy.orm import Session
 from app.api.schemas.notification import NotificationCreate, NotificationResponse, NotificationListResponse
-from app.db.sql.connection import get_db  # Assuming you have this dependency
+from app.db.sql.connection import get_db
 from app.services.notification_service import NotificationService
+from app.core.auth import get_current_service, ServiceTokenPayload
 
 notification_router = APIRouter(tags=["Notifications"])
 
@@ -11,8 +12,9 @@ def get_notification_service(db: Session = Depends(get_db)) -> NotificationServi
 
 @notification_router.post("/", response_model=NotificationResponse, status_code=status.HTTP_201_CREATED)
 async def create_notification(
-    request: NotificationCreate, 
-    notification_service: NotificationService = Depends(get_notification_service)
+    request: NotificationCreate,
+    notification_service: NotificationService = Depends(get_notification_service),
+    service: ServiceTokenPayload = Security(get_current_service, scopes=["notifications:write"]),
 ):
 
     """
@@ -43,8 +45,9 @@ async def create_notification(
 
 @notification_router.get("/{notification_id}", response_model=NotificationResponse)
 async def get_notification(
-    notification_id: str, 
-    notification_service: NotificationService = Depends(get_notification_service)
+    notification_id: str,
+    notification_service: NotificationService = Depends(get_notification_service),
+    service: ServiceTokenPayload = Security(get_current_service, scopes=["notifications:read"]),
 ):
     """
     Get a notification by ID.
@@ -74,7 +77,8 @@ async def get_notification(
 async def list_notifications(
     page: int = 1,
     page_size: int = 10,
-    notification_service: NotificationService = Depends(get_notification_service)
+    notification_service: NotificationService = Depends(get_notification_service),
+    service: ServiceTokenPayload = Security(get_current_service, scopes=["notifications:read"]),
 ):
     """
     List all notifications with pagination.

--- a/app/core/auth.py
+++ b/app/core/auth.py
@@ -1,0 +1,98 @@
+import jwt
+from datetime import datetime, timezone, timedelta
+from typing import Optional, Dict, Any
+from fastapi import HTTPException, Security
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from pydantic import BaseModel
+from app.core.config import settings
+import logging
+
+logger = logging.getLogger(__name__)
+
+security = HTTPBearer()
+
+
+class ServiceTokenPayload(BaseModel):
+    """JWT payload for service-to-service auth."""
+    service_id: str
+    scope: list[str]
+    exp: datetime
+    iat: datetime
+
+
+class ServiceTokenResponse(BaseModel):
+    """Response model for token generation."""
+    access_token: str
+    token_type: str = "bearer"
+    expires_in: int
+
+
+def create_service_token(service_id: str, scope: list[str]) -> ServiceTokenResponse:
+    """
+    Create a JWT token for a service.
+    Tokens expire after JWT_EXPIRY_MINUTES (default 60).
+    """
+    now = datetime.now(timezone.utc)
+    payload = {
+        "service_id": service_id,
+        "scope": scope,
+        "exp": now + timedelta(minutes=settings.JWT_EXPIRY_MINUTES),
+        "iat": now,
+    }
+    token = jwt.encode(payload, settings.JWT_SECRET_KEY, algorithm=settings.JWT_ALGORITHM)
+    return ServiceTokenResponse(
+        access_token=token,
+        expires_in=settings.JWT_EXPIRY_MINUTES * 60,
+    )
+
+
+def verify_service_token(token: str) -> ServiceTokenPayload:
+    """
+    Verify a service JWT token.
+    Returns the decoded payload if valid.
+    Raises HTTPException 401 if invalid or expired.
+    """
+    try:
+        payload = jwt.decode(
+            token,
+            settings.JWT_SECRET_KEY,
+            algorithms=[settings.JWT_ALGORITHM],
+        )
+        return ServiceTokenPayload(**payload)
+    except jwt.ExpiredSignatureError:
+        logger.warning("Service token expired", extra={"error": "token_expired"})
+        raise HTTPException(401, "Token expired")
+    except jwt.InvalidTokenError as e:
+        logger.warning("Invalid service token", extra={"error": str(e)})
+        raise HTTPException(401, "Invalid token")
+
+
+def get_current_service(
+    credentials: HTTPAuthorizationCredentials = Security(security),
+) -> ServiceTokenPayload:
+    """
+    FastAPI dependency to validate JWT and return current service identity.
+    Use as: `def endpoint(..., service: ServiceTokenPayload = Depends(get_current_service))`
+    """
+    return verify_service_token(credentials.credentials)
+
+
+def require_scope(required_scope: str):
+    """
+    FastAPI dependency factory that checks if the service has required scope.
+    Usage: `def endpoint(..., service: ServiceTokenPayload = Depends(require_scope("notifications:write")))`
+    """
+    def scope_checker(
+        credentials: HTTPAuthorizationCredentials = Security(security),
+    ) -> ServiceTokenPayload:
+        payload = verify_service_token(credentials.credentials)
+        if required_scope not in payload.scope:
+            logger.warning("Insufficient scope", extra={
+                "service_id": payload.service_id,
+                "required_scope": required_scope,
+                "actual_scope": payload.scope,
+            })
+            raise HTTPException(403, f"Missing required scope: {required_scope}")
+        return payload
+
+    return scope_checker

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -75,6 +75,14 @@ class Settings(BaseSettings):
     # Push Notification Configuration (optional - Firebase)
     FCM_SERVER_KEY: Optional[str] = None
 
+    # JWT Service Auth
+    JWT_SECRET_KEY: str = "your-super-secret-key-change-in-production-min-32-chars"
+    JWT_ALGORITHM: str = "HS256"
+    JWT_EXPIRY_MINUTES: int = 60
+
+    # Service-to-service auth
+    SERVICE_API_SECRET: str = "service-secret-change-in-production"
+
     model_config = {
         "env_file": ".env",
         "env_file_encoding": "utf-8",

--- a/app/main.py
+++ b/app/main.py
@@ -3,6 +3,7 @@ from fastapi import FastAPI
 import logging
 
 from app.api.endpoints.notification import notification_router
+from app.api.endpoints.auth import router as auth_router
 from app.core.logging_config import configure_logging
 
 logger = logging.getLogger(__name__)
@@ -36,6 +37,7 @@ app = FastAPI(
 )
 
 app.include_router(notification_router, prefix="/api/v1/notifications", tags=["Notifications"])
+app.include_router(auth_router, prefix="/api/v1/auth", tags=["Auth"])
 
 @app.get("/")
 async def read_root():

--- a/app/tests/api/test_auth.py
+++ b/app/tests/api/test_auth.py
@@ -1,0 +1,139 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from fastapi.testclient import TestClient
+from app.main import app
+from app.core.auth import create_service_token, verify_service_token, ServiceTokenPayload
+from datetime import datetime, timezone
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+class TestServiceToken:
+    """Unit tests for service token creation and verification."""
+
+    def test_create_and_verify_token(self):
+        """Test that a created token can be verified."""
+        token_response = create_service_token(
+            service_id="test-service",
+            scope=["notifications:read", "notifications:write"],
+        )
+        payload = verify_service_token(token_response.access_token)
+
+        assert payload.service_id == "test-service"
+        assert "notifications:read" in payload.scope
+        assert "notifications:write" in payload.scope
+
+    def test_verify_invalid_token_raises(self):
+        """Test that an invalid token raises HTTPException 401."""
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc_info:
+            verify_service_token("invalid.token.here")
+        assert exc_info.value.status_code == 401
+
+    def test_token_payload_model(self):
+        """Test ServiceTokenPayload model."""
+        now = datetime.now(timezone.utc)
+        payload = ServiceTokenPayload(
+            service_id="svc-1",
+            scope=["test:read"],
+            exp=now,
+            iat=now,
+        )
+        assert payload.service_id == "svc-1"
+        assert payload.scope == ["test:read"]
+
+
+class TestAuthEndpoints:
+    """Integration tests for auth endpoints."""
+
+    def test_get_token_with_valid_credentials(self, client):
+        """Test token endpoint with valid credentials."""
+        response = client.post(
+            "/api/v1/auth/token",
+            json={
+                "service_id": "test-service",
+                "service_secret": "service-secret-change-in-production",
+                "scope": ["notifications:read"],
+            },
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert "access_token" in data
+        assert data["token_type"] == "bearer"
+        assert data["expires_in"] == 3600
+
+    def test_get_token_with_invalid_credentials(self, client):
+        """Test token endpoint with invalid credentials returns 401."""
+        response = client.post(
+            "/api/v1/auth/token",
+            json={
+                "service_id": "test-service",
+                "service_secret": "wrong-secret",
+            },
+        )
+        assert response.status_code == 401
+        assert response.json()["detail"] == "Invalid service credentials"
+
+    def test_protected_endpoint_without_token(self, client):
+        """Test that protected endpoints require authentication."""
+        response = client.post(
+            "/api/v1/notifications/",
+            json={
+                "subject": "Test",
+                "content": "Hello",
+                "channel": "email",
+                "user_ids": [1],
+                "emails": ["test@example.com"],
+                "priority": "high",
+            },
+        )
+        assert response.status_code == 401  # HTTPBearer returns 401 when no auth header
+
+    def test_protected_endpoint_with_valid_token(self, client):
+        """Test that protected endpoints work with valid token."""
+        # First get a token
+        token_response = client.post(
+            "/api/v1/auth/token",
+            json={
+                "service_id": "test-service",
+                "service_secret": "service-secret-change-in-production",
+            },
+        )
+        token = token_response.json()["access_token"]
+
+        # Now call protected endpoint
+        response = client.post(
+            "/api/v1/notifications/",
+            json={
+                "subject": "Test",
+                "content": "Hello",
+                "channel": "email",
+                "user_ids": [1],
+                "emails": ["test@example.com"],
+                "priority": "high",
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        # Either 201 (success) or 400/500 (business error) — not 401/403
+        assert response.status_code != 401
+        assert response.status_code != 403
+
+    def test_protected_endpoint_with_invalid_token(self, client):
+        """Test that invalid token returns 401."""
+        response = client.post(
+            "/api/v1/notifications/",
+            json={
+                "subject": "Test",
+                "content": "Hello",
+                "channel": "email",
+                "user_ids": [1],
+                "emails": ["test@example.com"],
+                "priority": "high",
+            },
+            headers={"Authorization": "Bearer invalid.token.here"},
+        )
+        assert response.status_code == 401

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "psycopg2-binary>=2.9.10",
     "pydantic-settings>=2.9.1",
     "pymongo>=4.13.0",
+    "pyjwt>=2.9.0",
     "pytest>=8.4.1",
     "pytest-asyncio>=1.0.0",
     "pytest-cov>=6.2.1",


### PR DESCRIPTION
## Summary
- JWT service-to-service auth (HS256)
- `POST /api/v1/auth/token` — mint tokens with service credentials
- All notification endpoints protected with Bearer JWT
- Scope-based access: `notifications:read`, `notifications:write`

## Test plan
- [x] 8 auth tests pass
- [x] Token mint works with valid credentials
- [x] Protected endpoints reject unauthenticated requests
- [x] Protected endpoints work with valid JWT

## Files
- `app/core/auth.py` — token mint/verify, `require_scope()` dependency
- `app/api/endpoints/auth.py` — `/auth/token` endpoint
- `app/api/endpoints/notification.py` — auth on all endpoints
- `app/core/config.py` — JWT config vars + `SERVICE_API_SECRET`
- `app/tests/api/test_auth.py` — 8 tests